### PR TITLE
Reduce XML output size

### DIFF
--- a/lib/fedex/request/rate.rb
+++ b/lib/fedex/request/rate.rb
@@ -71,7 +71,7 @@ module Fedex
             add_requested_shipment(xml)
           }
         end
-        builder.doc.root.to_xml
+        builder.doc.root.to_xml(:save_with => Nokogiri::XML::Node::SaveOptions::AS_XML)
       end
 
       def service


### PR DESCRIPTION
To get around some of the issues with maximum request sizes on the FedEx rate API, this removes most of the excess whitespace and newlines that are created in `to_xml` by default. Based on [this answer from Stack Overflow](https://stackoverflow.com/a/8406635)